### PR TITLE
fix InstallerX-Revived md link & add chinese readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,7 +199,7 @@ Pull requests are welcome. See [Contributing](CONTRIBUTING.md) for hints.
 * [Droid-ify](https://f-droid.org/packages/com.looker.droidify/) - Material F-Droid client `GPL-3.0` [(Source code)](https://github.com/Droid-ify/client)
 * [ffupdater](https://f-droid.org/packages/de.marmaro.krt.ffupdater/) - FFUpdater: Updater for privacy-friendly browser `GPL-3.0` [(Source code)](https://github.com/Tobi823/ffupdater)
 * [instafel-updater](https://github.com/mamiiblt/instafel-updater) - Updater app for Instafel, an Instagram mod `Apache-2.0`
-* [InstallerX-Revived](https://github.com/wxxsfxyzm/InstallerX-Revived/blob/main/docs/README.md) ✨ - Modern and functional Android app installer replacement `GPL-3.0`
+* [InstallerX-Revived](https://github.com/wxxsfxyzm/InstallerX-Revived) ✨ - Modern and functional Android app installer replacement `GPL-3.0`
 * [InstallWithOptions](https://github.com/zacharee/InstallWithOptions) -  Simple-ish app using Shizuku to install APKs on-device with advanced options `MIT`
 * [IzzyOnDroid](https://gitlab.com/sunilpaulmathew/izzyondroid) - An unofficial client for IzzyOnDroid F-Droid Repository `GPL-3.0`
 * [Obtainium](https://github.com/ImranR98/Obtainium) - Get Android App Updates Directly From the Source `GPL-3.0`

--- a/README_cn.md
+++ b/README_cn.md
@@ -179,7 +179,7 @@ Shizuku 允许普通应用程序在非root 设备上使用 ADB 直接使用权�
 * [fdroid_shizuku_privileged_extension](https://depau.github.io/fdroid_shizuku_privileged_extension/fdroid/repo/) - 与 Shizuku 协同工作的 F-Droid 权限扩展`Apache-2.0` [(源代码)](https://github.com/depau/fdroid_shizuku_privileged_extension)
 * [ffupdater](https://f-droid.org/packages/de.marmaro.krt.ffupdater/) - FFUpdater：隐私友好浏览器的更新程序 `GPL-3.0` [(源代码)](https://github.com/Tobi823/ffupdater)
 * [glassdown](https://github.com/Sinneida/glassdown) - APKMirror 客户端 `GPL-3.0`
-* [InstallerX-Revived](https://github.com/wxxsfxyzm/InstallerX-Revived/blob/main/docs/README_CN.md) ✨ - 现代且实用的 Android 应用安装程序替代品 `GPL-3.0`
+* [InstallerX-Revived](https://github.com/wxxsfxyzm/InstallerX-Revived) ✨ - 现代且实用的 Android 应用安装程序替代品 `GPL-3.0`
 * [InstallWithOptions](https://github.com/zacharee/InstallWithOptions) - 简单的应用程序使用 Shizuku 在设备上安装带有高级选项的 APK `MIT`
 * [IzzyOnDroid](https://gitlab.com/sunilpaulmathew/izzyondroid) - IzzyOnDroid F-Droid 存储库的非官方客户端`GPL-3.0`
 * [Obtainium](https://github.com/ImranR98/Obtainium) - 直接从源获取 Android 应用程序更新 `GPL-3.0`


### PR DESCRIPTION
InstallerX-Revived has moved their readme files to a docs folder.
Since the link was specifically pointing to the old .md file, it was broken.
No need to point to .md as it's the default & it prevents errors like this in the future.

This PR updates the link.
Also it wasn't in the readme_cn file, so I added it.