### PR TITLE
Add Related Lists section with awesome-android-customization

### DIFF
--- a/README.md
+++ b/README.md
@@ -451,6 +451,12 @@ The official rish documentation is available here: https://github.com/RikkaApps/
 
 --------------------
 
+## Related Lists
+
+- [awesome-android-customization](https://github.com/OutrageousStorm/awesome-android-customization) - Broader Android customization list covering launchers, icon packs, ROMs, debloating tools, and ADB cheat sheets. Includes Shizuku apps alongside other no-root methods.
+
+--------------------
+
 ## License
 
 This list is licensed under the [Creative Commons Attribution-ShareAlike 3.0 Unported](https://creativecommons.org/licenses/by-sa/3.0/deed.en) License.


### PR DESCRIPTION
Adds a `Related Lists` section pointing to [awesome-android-customization](https://github.com/OutrageousStorm/awesome-android-customization) — a complementary list covering the broader no-root ecosystem: Shizuku apps, ADB tools, launchers, ROMs, debloating guides, and privacy tools.

These lists are complementary rather than overlapping. Users who find awesome-shizuku are very likely to benefit from the broader context.