### PR TITLE
Add Android Permission Auditor to Privacy section

### DIFF
--- a/README.md
+++ b/README.md
@@ -286,6 +286,7 @@ Pull requests are welcome. See [Contributing](CONTRIBUTING.md) for hints.
 * [AntiForensic-Tools](https://github.com/bakad3v/Android-AntiForensic-Tools) - An application designed to silently protect user data from powerful adversaries `GPL-3.0`
 * [AppLock](https://github.com/PranavPurwar/AppLock) ✨ - Lock sensitive apps with a PIN and optionally biometrics `MIT`
 * [PrivacyFlip](https://f-droid.org/en/packages/io.github.dorumrr.privacyflip/) - Manage your device privacy based on lock/unlock state `MIT` [(Source code)](https://github.com/dorumrr/privacyflip)
+* [Android Permission Auditor](https://github.com/OutrageousStorm/android-permission-auditor) - Audit every app's dangerous permissions via ADB and generate revoke scripts `MIT`
 
 ### Productivity
 


### PR DESCRIPTION
## New tool: Android Permission Auditor

**Repo:** https://github.com/OutrageousStorm/android-permission-auditor

**Description:** ADB-based tool that audits every installed app's dangerous permissions and generates ready-to-run `pm revoke` scripts for privacy hardening.

**Checklist:**
- [x] The entry follows the format in CONTRIBUTING.md
- [x] License is MIT and open source
- [x] Directly uses ADB/Shizuku-compatible shell commands (no root required)
- [x] Added to the correct section: **Privacy**

This fills a gap — there are hider/lock apps in the Privacy section but nothing that audits and bulk-revokes permissions across all apps. This is the ADB command-line companion to tools like App Manager.