### PR TITLE
Revise PrecisEQ description in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ Pull requests are welcome. See [Contributing](CONTRIBUTING.md) for hints.
 * [RootlessJamesDSP](https://play.google.com/store/apps/details?id=me.timschneeberger.rootlessjamesdsp) - An implementation of the system-wide JamesDSP audio processing engine for non-rooted Android devices `GPL-3.0` [(Source code)](https://github.com/timschneeb/RootlessJamesDSP)
 * [MicUp](https://github.com/papergray/MicUp) ✨ - Real-time microphone audio processing for Android `MIT`
 * [VolumeManager](https://github.com/yume-chan/VolumeManager) - Control each app's volume independently `GPL-2.0`
-* [PrecisEQ](https://play.google.com/store/apps/details?id=com.yokodev.preciseqpro) `Paid/IAP` `30-second trial` 💰 - Use spatial audio, headphone calibration, and parametric equalizer system-wide. `Proprietary`
+* [PrecisEQ](https://play.google.com/store/apps/details?id=com.yokodev.preciseqpro) `IAP` 💰 - Use spatial audio, headphone calibration, PEQ and convolver system-wide. `Proprietary`
 
 ### Automation
 


### PR DESCRIPTION
The duration of a single, full-feature session is 15 minutes, not 30 seconds. Users are encouraged to restart these sessions infinitely to thoroughly evaluate the app's functionality and compatibility before making a purchase—or they can simply choose not to pay and continue using it manually.

The In-App Purchase is an optional way to support the project and subsidize the high overhead of purchasing, measuring, and professionally calibrating the wide variety of headphones supported by PrecisEQ.
<img width="1440" height="1180" alt="Screenshot_20260419_074005_PrecisEQ" src="https://github.com/user-attachments/assets/e9296526-0671-44e9-bdcd-a1766caa493a" />


