### PR TITLE
Add Mythara to AI agents — local-first agentic AI OS layer for Android

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ Pull requests are welcome. See [Contributing](CONTRIBUTING.md) for hints. Closed
 
 ### AI agents
 
+* [Mythara](https://github.com/ankurCES/project_mythara) - Open-source local-first agentic AI OS layer for Android. Runs 65+ on-device tools (calls, SMS, calendar, Termux, face recognition); uses Shizuku for cosmetic system tweaks (font scale, dark mode, accent) without root `MIT`
 * [Open-AutoGLM-Android](https://github.com/xinzezhu/Open-AutoGLM-Android/blob/main/README_EN.md) - Automates actions on your device using the AutoGLM vision language model `GPL-3.0`
 * [Operit AI](https://github.com/AAswordman/Operit) - The most powerful AI agent and AI chat software on Android. Can run commands using Shizuku `LGPL-3.0`
 * [Ruto-GLM](https://github.com/iamr0s/Ruto-GLM/blob/main/README_en.md) - Automation and Multitasking Framework using AutoGLM. Can create virtual screens that agents can run apps on and use multi-window `Apache 2.0`


### PR DESCRIPTION
## What this adds

A new entry under **Apps → AI agents** (alphabetically first):

```
* [Mythara](https://github.com/ankurCES/project_mythara) - Open-source local-first agentic AI OS layer for Android. Runs 65+ on-device tools (calls, SMS, calendar, Termux, face recognition); uses Shizuku for cosmetic system tweaks (font scale, dark mode, accent) without root `MIT`
```

## Why it uses Shizuku

Mythara's `apply_cosmetic` agent tool routes through Shizuku to apply allowlisted system settings (`font_scale`, `ui_night_mode`, `accent_color`, `display_density_forced`, `navigation_mode`, etc.) — all of which require `WRITE_SECURE_SETTINGS`. When Shizuku isn't installed, the tool degrades gracefully and surfaces a setup card; when it is, the user can ask the agent to tweak system look-and-feel without rooting the device.

Shizuku integration files:
- `services/ShizukuService.kt` — singleton wrapper around `Shizuku.pingBinder()` + permission flow
- `agent/tools/CosmeticTool.kt` — allowlisted `settings put` via Shizuku
- `ui/settings/ShizukuSetupPanel.kt` — onboarding card when Shizuku isn't running

## Compliance

- [x] License: MIT
- [x] Project has an English readme + wiki ([wiki](https://github.com/ankurCES/project_mythara/wiki))
- [x] Project is not deprecated (actively maintained)
- [x] Download link present (build instructions in [Build & Install](https://github.com/ankurCES/project_mythara/wiki/Build-and-Install))
- [x] Format matches existing entries — alphabetical placement (M before O), short description under 250 chars, SPDX license identifier (`MIT`)