### PR TITLE
Add rish-mcp to AI agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ Pull requests are welcome. See [Contributing](CONTRIBUTING.md) for hints. Closed
 * [Mythara](https://github.com/ankurCES/project_mythara) - Open-source local-first agentic AI OS layer for Android. Runs 65+ on-device tools (calls, SMS, calendar, Termux, face recognition); uses Shizuku for cosmetic system tweaks (font scale, dark mode, accent) without root `MIT`
 * [Open-AutoGLM-Android](https://github.com/xinzezhu/Open-AutoGLM-Android/blob/main/README_EN.md) - Automates actions on your device using the AutoGLM vision language model `GPL-3.0`
 * [Operit AI](https://github.com/AAswordman/Operit) - The most powerful AI agent and AI chat software on Android. Can run commands using Shizuku `LGPL-3.0`
+* [rish-mcp](https://github.com/turin-dev/rish-mcp) - Exposes an Android device's Shizuku shell to AIs as an MCP `run_shell` tool over an outbound WebSocket relay — run shell commands from Claude or any MCP client with no VPN, ADB, or sshd `MIT`
 * [Ruto-GLM](https://github.com/iamr0s/Ruto-GLM/blob/main/README_en.md) - Automation and Multitasking Framework using AutoGLM. Can create virtual screens that agents can run apps on and use multi-window `Apache 2.0`
 
 


### PR DESCRIPTION
Adds **rish-mcp** under **Apps → AI agents** (inserted in alphabetical order).

[rish-mcp](https://github.com/turin-dev/rish-mcp) exposes an Android device's Shizuku shell to AIs as an MCP `run_shell` tool. The phone runs a small Shizuku-backed agent that holds an outbound WebSocket to a relay, so any MCP client (e.g. Claude) can run shell commands (uid 2000) on the device with no VPN, ADB, or sshd.

Checklist vs CONTRIBUTING:
- [x] Alphabetical order within the section
- [x] Format `* [Name](url) - description \`License\``
- [x] Description under 250 characters
- [x] SPDX license tag (`MIT`)
- [x] No duplicate source-code link (main link is the source repo)
- [x] Open source, English README, not deprecated
- [x] Download link provided — signed APK on the [v0.2.0 release](https://github.com/turin-dev/rish-mcp/releases/tag/v0.2.0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)